### PR TITLE
Fix bug adding duplicate field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.2.3
+* Fix bug that added duplcate field names to Model#field_names.
+
 ### 0.2.2
 * Fix bug requiring support codez in lib/deco_lite.rb.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deco_lite (0.2.2)
+    deco_lite (0.2.3)
       activemodel (~> 7.0, >= 7.0.3.1)
       activesupport (~> 7.0, >= 7.0.3.1)
       immutable_struct_ex (~> 0.2.0)

--- a/lib/deco_lite/hash_loadable.rb
+++ b/lib/deco_lite/hash_loadable.rb
@@ -19,7 +19,7 @@ module DecoLite
       load_service.execute(hash: hash, options: load_service_options).tap do |h|
         h.each_pair do |field_name, value|
           create_field_accessor field_name: field_name, options: deco_lite_options
-          field_names << field_name
+          field_names << field_name unless field_names.include? field_name
           set_field_value(field_name: field_name, value: value, options: deco_lite_options)
         end
       end

--- a/lib/deco_lite/version.rb
+++ b/lib/deco_lite/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the version of this gem.
 module DecoLite
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end

--- a/spec/features/model_spec.rb
+++ b/spec/features/model_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'DecoLite::Model features', type: :features do
       end
     end
 
-    context 'when loading fields conflict with existing attributes' do
+    context 'when loading fields conflict with existing attributes and option fields: :strict' do
       subject do
         Class.new(DecoLite::Model) do
           attr_accessor :existing_field
@@ -33,6 +33,30 @@ RSpec.describe 'DecoLite::Model features', type: :features do
       end
 
       it_behaves_like 'an error is raised'
+    end
+
+    context 'when loading fields conflict with existing attributes and option fields: :merge' do
+      subject do
+        Class.new(DecoLite::Model) do
+          attr_accessor :existing_field
+        end.new(options: options).load(hash: hash)
+      end
+
+      before do
+        subject.load(hash: { existing_field: new_value} )
+      end
+
+      let(:hash) { { existing_field: :existing_field } }
+      let(:options) { { fields: DecoLite::FieldsOptionable::OPTION_FIELDS_MERGE } }
+      let(:new_value) { :new_value }
+
+      it 'replaces the field value' do
+        expect(subject.existing_field).to eq new_value
+      end
+
+      it 'does not create duplicate #field_names' do
+        expect(subject.field_names).to match_array [:existing_field]
+      end
     end
   end
 


### PR DESCRIPTION
- Add specs to check bug fix.
- Add spec to make sure duplicate field values are replaced
when option fields: :merge is used.