### PR TITLE
Miscellaneous refactors and bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.2.4
+* Changes
+  * Change DecoLite::Model#load to #load! as it alters the object, give deprecation warning when calling #load.
+  * FieldConflictable now expliticly prohibits loading fields that conflict with attributes that are native to the receiver. In other words, you cannot load fields with names like :to_s, :tap, :hash, etc.
+  * FieldCreatable now creates attr_accessors on the instance using #define_singleton_method, not at the class level (i.e. self.class.attr_accessor) (see bug fixes).
+* bug fixes
+  * Fix bug that used self.class.attr_accessor in DecoLite::FieldCreatable to create attributes, which forced every object of that class subsequently created have the accessors created which caused field name conflicts across DecoLite::Model objects.
+
 ### 0.2.3
 * Fix bug that added duplcate field names to Model#field_names.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deco_lite (0.2.3)
+    deco_lite (0.2.4)
       activemodel (~> 7.0, >= 7.0.3.1)
       activesupport (~> 7.0, >= 7.0.3.1)
       immutable_struct_ex (~> 0.2.0)

--- a/README.md
+++ b/README.md
@@ -170,6 +170,29 @@ model.wife_info_age         #=> 20
 model.wife_info_address     #=> 1 street, boonton, nj 07005
 ```
 
+### Manually Defining Attributes
+
+Manually defining attributes on your subclass is possible; however, you
+must add your attr_reader name to the `DecoLite::Model@field_names` array, or an error will be reaised _if_ there are any conflicting field names being loaded
+using `DecoLite::Model#load!`, regardless of setting the `{ fields: :merge }`
+option. This is because DecoLite assumes any existing attributes not added to
+the model via `load!`to be native to the object created, and therefore will not
+allow you to create attr_accessors for existing attributes, as this can potentially be dangerous.
+
+To avoid errors when manually defining attributes on the model that could potentially be in conflict with fields loaded using `DecoLite::Model#load!`, do the following:
+
+```ruby
+class JustBecauseYouCanDoesntMeanYouShould < DecoLite::Model
+  attr_accessor :existing_field
+
+  def initialize(options: {})
+    super
+
+    @field_names = %i(existing_field)
+  end
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/deco_lite.rb
+++ b/lib/deco_lite.rb
@@ -3,6 +3,7 @@
 require_relative 'deco_lite/field_assignable'
 require_relative 'deco_lite/field_conflictable'
 require_relative 'deco_lite/field_creatable'
+require_relative 'deco_lite/field_names_persistable'
 require_relative 'deco_lite/field_requireable'
 require_relative 'deco_lite/field_retrievable'
 require_relative 'deco_lite/fields_optionable'

--- a/lib/deco_lite/field_conflictable.rb
+++ b/lib/deco_lite/field_conflictable.rb
@@ -9,15 +9,36 @@ module DecoLite
     include FieldsOptionable
 
     def validate_field_conflicts!(field_name:, options:)
-      return unless options.strict? && field_conflict?(field_name: field_name)
+      return unless field_conflict?(field_name: field_name, options: options)
 
-      raise "Field '#{field_name}' conflicts with existing attribute; " \
-        'this will raise an error when running in strict mode: ' \
-        "options: { #{OPTION_FIELDS}: :#{OPTION_FIELDS_STRICT} }."
+      raise "Field :#{field_name} conflicts with existing method(s) " \
+        ":#{field_name} and/or :#{field_name}=; " \
+        'this will raise an error when loading using strict mode ' \
+        "(i.e. options: { #{OPTION_FIELDS}: :#{OPTION_FIELDS_STRICT} }) " \
+        'or if the method(s) are native to the object (e.g :to_s, :==, etc.).'
     end
 
-    def field_conflict?(field_name:)
-      respond_to? field_name
+    # This method returns true
+    def field_conflict?(field_name:, options:)
+      # If field_name was already added using Model#load, there is only a
+      # conflict if options.strict? is true.
+      if field_names_include?(field_name: field_name)
+        return options.strict?
+      end
+
+      # If we get here, we know that :field_name does not exist as an
+      # attribute on the model. If the attribute already exists on the
+      # model, this is a conflict because we cannot override an attribute
+      # that already exists on the model
+      attr_accessor_exist?(field_name: field_name)
+    end
+
+    def field_names_include?(field_name:)
+      field_names.include? field_name
+    end
+
+    def attr_accessor_exist?(field_name:)
+      respond_to?(field_name) || respond_to?(:"#{field_name}=")
     end
   end
 end

--- a/lib/deco_lite/field_creatable.rb
+++ b/lib/deco_lite/field_creatable.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative 'field_conflictable'
+require_relative 'field_validatable'
 
 module DecoLite
   # Takes an array of symbols and creates attr_accessors.
   module FieldCreatable
     include FieldConflictable
+    include FieldValidatable
 
     def create_field_accessors(field_names:, options:)
       return if field_names.blank?
@@ -16,9 +18,28 @@ module DecoLite
     end
 
     def create_field_accessor(field_name:, options:)
+      validate_field_name!(field_name: field_name, options: options)
       validate_field_conflicts!(field_name: field_name, options: options)
 
-      self.class.attr_accessor(field_name) if field_name.present?
+      # If we want to set a class-level attr_accessor
+      # self.class.attr_accessor(field_name) if field_name.present?
+
+      create_field_getter field_name: field_name, options: options
+      create_field_setter field_name: field_name, options: options
+    end
+
+    private
+
+    def create_field_getter(field_name:, options:)
+      define_singleton_method(field_name) do
+        instance_variable_get "@#{field_name}"
+      end
+    end
+
+    def create_field_setter(field_name:, options:)
+      define_singleton_method("#{field_name}=") do |value|
+        instance_variable_set "@#{field_name}", value
+      end
     end
   end
 end

--- a/lib/deco_lite/field_names_persistable.rb
+++ b/lib/deco_lite/field_names_persistable.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module DecoLite
+  # Takes an array of symbols and creates attr_accessors.
+  module FieldNamesPersistable
+    def field_names
+      @field_names ||= instance_variable_get(:@field_names) || []
+    end
+
+    private
+
+    attr_writer :field_names
+  end
+end

--- a/lib/deco_lite/field_validatable.rb
+++ b/lib/deco_lite/field_validatable.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module DecoLite
+  # Defines methods validate field (attribute) names.
+  module FieldValidatable
+    FIELD_NAME_REGEX = /\A(?:[a-z_]\w*[?!=]?|\[\]=?|<<|>>|\*\*|[!~+\*\/%&^|-]|[<>]=?|<=>|={2,3}|![=~]|=~)\z/i.freeze
+
+    module_function
+
+    def validate_field_name!(field_name:, options: nil)
+      unless field_name =~ FIELD_NAME_REGEX
+        raise "field_name '#{field_name}' is not a valid field name."
+      end
+    end
+  end
+end

--- a/lib/deco_lite/model.rb
+++ b/lib/deco_lite/model.rb
@@ -3,6 +3,7 @@
 require 'active_model'
 require_relative 'field_creatable'
 require_relative 'field_requireable'
+require_relative 'field_names_persistable'
 require_relative 'hash_loadable'
 require_relative 'hashable'
 require_relative 'model_nameable'
@@ -14,6 +15,7 @@ module DecoLite
   class Model
     include ActiveModel::Model
     include FieldCreatable
+    include FieldNamesPersistable
     include FieldRequireable
     include HashLoadable
     include Hashable
@@ -24,6 +26,7 @@ module DecoLite
 
     def initialize(options: {})
       @field_names = []
+
       # Accept whatever options are sent, but make sure
       # we have defaults set up. #options_with_defaults
       # will merge options into OptionsDefaultable::DEFAULT_OPTIONS
@@ -32,7 +35,7 @@ module DecoLite
       self.options = Options.with_defaults options
     end
 
-    def load(hash:, options: {})
+    def load!(hash:, options: {})
       # Merge options into the default options passed through the
       # constructor; these will override any options passed in when
       # this object was created, allowing us to retain any defaut
@@ -45,10 +48,11 @@ module DecoLite
       self
     end
 
-    attr_reader :field_names
+    def load(hash:, options: {})
+      puts 'WARNING: DecoLite::Model#load will be deprecated in a future release;' \
+        ' use DecoLite::Model#load! instead!'
 
-    private
-
-    attr_writer :field_names
+        load!(hash: hash, options: options)
+    end
   end
 end

--- a/lib/deco_lite/version.rb
+++ b/lib/deco_lite/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the version of this gem.
 module DecoLite
-  VERSION = '0.2.3'
+  VERSION = '0.2.4'
 end

--- a/spec/features/model_spec.rb
+++ b/spec/features/model_spec.rb
@@ -29,16 +29,22 @@ RSpec.describe 'DecoLite::Model features', type: :features do
       let(:hash) { { existing_field: :existing_field } }
       let(:options) { { fields: DecoLite::FieldsOptionable::OPTION_FIELDS_STRICT } }
       let(:expected_error) do
-        /Field 'existing_field' conflicts with existing attribute/
+        /Field :existing_field conflicts with existing method\(s\)/
       end
 
       it_behaves_like 'an error is raised'
     end
 
     context 'when loading fields conflict with existing attributes and option fields: :merge' do
-      subject do
+      subject! do
         Class.new(DecoLite::Model) do
           attr_accessor :existing_field
+
+          def initialize(options: {})
+            super
+
+            @field_names = %i(existing_field)
+          end
         end.new(options: options).load(hash: hash)
       end
 
@@ -49,6 +55,8 @@ RSpec.describe 'DecoLite::Model features', type: :features do
       let(:hash) { { existing_field: :existing_field } }
       let(:options) { { fields: DecoLite::FieldsOptionable::OPTION_FIELDS_MERGE } }
       let(:new_value) { :new_value }
+
+      it_behaves_like 'there are no errors'
 
       it 'replaces the field value' do
         expect(subject.existing_field).to eq new_value

--- a/spec/lib/deco_lite/field_assignable_spec.rb
+++ b/spec/lib/deco_lite/field_assignable_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe DecoLite::FieldAssignable, type: :module do
   subject(:klass) do
     class AwesomeKlass
       include DecoLite::FieldAssignable
+      include DecoLite::FieldNamesPersistable
     end.new
   end
   let(:field_name) { loadable_hash_field_info.first[1][:field_name] }

--- a/spec/lib/deco_lite/field_requireable_spec.rb
+++ b/spec/lib/deco_lite/field_requireable_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe DecoLite::FieldRequireable, type: :module do
       include ActiveModel::Model
       include DecoLite::FieldCreatable
       include DecoLite::FieldRequireable
+      include DecoLite::FieldNamesPersistable
 
       def initialize(field_names:, options:)
         create_field_accessors field_names: field_names, options: options

--- a/spec/lib/deco_lite/field_validatable_spec.rb
+++ b/spec/lib/deco_lite/field_validatable_spec.rb
@@ -1,0 +1,31 @@
+RSpec.shared_examples 'the field_name is valid' do |field_name, options|
+  it 'does not raise an error' do
+    expect do
+      subject.validate_field_name!(field_name: field_name, options: options)
+    end.to_not raise_error
+  end
+end
+
+RSpec.shared_examples 'the field_name is invalid' do |field_name, options|
+  it 'raises an error' do
+    expect do
+      subject.validate_field_name!(field_name: field_name, options: options)
+    end.to raise_error "field_name '#{field_name}' is not a valid field name."
+  end
+end
+
+RSpec.describe DecoLite::FieldValidatable, type: :module do
+  subject { described_class }
+
+  let(:options) { DecoLite::Options.default }
+
+  context 'when the field_name is valid' do
+    it_behaves_like 'the field_name is valid', :some_field
+    it_behaves_like 'the field_name is valid', 'some_field'
+  end
+
+  context 'when the field_name is invalid' do
+    it_behaves_like 'the field_name is invalid', :'some_field===='
+    it_behaves_like 'the field_name is invalid', 'some field'
+  end
+end

--- a/spec/lib/deco_lite/model_spec.rb
+++ b/spec/lib/deco_lite/model_spec.rb
@@ -3,60 +3,103 @@
 RSpec.describe DecoLite::Model, type: :model do
   subject do
     described_class.new(options: options)
-      .load(hash: hash, options: load_options)
+      .load!(hash: hash, options: load_options)
   end
 
   describe '#initialize' do
     context 'with no options' do
       it 'does not raise an error' do
-        expect { subject }.to_not raise_error
+        expect { described_class.new }.to_not raise_error
       end
     end
 
     context 'with valid options' do
-      subject { described_class.new(options: default_options) }
-
-      it 'does not raise an error' do
-        expect { subject }.to_not raise_error
+      subject do
+        described_class.new(options: default_options)
+          .load!(hash: hash)
       end
+
+     it_behaves_like 'there are no errors'
     end
   end
 
-  describe '#load' do
+  describe '#load!' do
     context 'when the arguments are valid' do
-      it 'does not raise an error' do
-        expect { subject }.to_not raise_error
-      end
-
+      it_behaves_like 'there are no errors'
       it_behaves_like 'the fields are defined'
       it_behaves_like 'the field values are what they should be'
+    end
 
-      context 'when passing a namespace' do
-        let(:load_options) { { namespace: :namespace } }
-        let(:namespace) { load_options[:namespace] }
+    context 'when passing a namespace' do
+      subject do
+        described_class.new(options: options)
+          .load!(hash: hash, options: load_options)
+      end
+      let(:load_options) { { namespace: :namespace } }
+      let(:namespace) { load_options[:namespace] }
 
-        it 'creates the fields using the namespace' do
-          expect(field_names.all? do |field_name|
-            subject.respond_to? "#{namespace}_#{field_name}".to_sym
-          end).to eq true
-        end
+      it 'creates the fields using the namespace' do
+        expect(field_names.all? do |field_name|
+          subject.respond_to? "#{namespace}_#{field_name}".to_sym
+        end).to eq true
+      end
 
-        it 'assigns the correct value' do
-          expect(field_names.all? do |field_name|
-            namespaced_field_name = "#{namespace}_#{field_name}".to_sym
-            subject.public_send(namespaced_field_name) == field_name
-          end).to eq true
-        end
+      it 'assigns the correct value' do
+        expect(field_names.all? do |field_name|
+          namespaced_field_name = "#{namespace}_#{field_name}".to_sym
+          subject.public_send(namespaced_field_name) == field_name
+        end).to eq true
       end
     end
 
     context 'when the arguments are invalid' do
       context 'when the object type is not handled' do
+        subject do
+          described_class.new(options: options)
+            .load!(hash: hash, options: load_options)
+        end
+
         let(:hash) { :not_handled }
         let(:expected_error) { "Argument hash is not a Hash (#{hash.class})" }
 
         it_behaves_like 'an error is raised'
       end
+    end
+
+    describe 'when loadig objects with the same fields' do
+      let(:model) do
+        described_class.new(options: options)
+            .load!(hash: hash, options: load_options)
+      end
+
+      it 'does not raise errors due to conflicting field names' do
+        expect do
+          described_class.new(options: options)
+            .load!(hash: hash, options: load_options)
+        end
+      end
+
+      it do
+        # Sanity check to make sure the same fields were loaded.
+        expect(model.to_h).to match subject.to_h
+      end
+    end
+  end
+
+  describe '#load' do
+    subject do
+      described_class.new(options: options)
+        .load(hash: hash, options: load_options)
+    end
+
+    it 'raises no errors' do
+      expect { subject }.to_not raise_error
+    end
+
+    it 'outputs a deprecation warning' do
+      warning = 'WARNING: DecoLite::Model#load will be deprecated ' \
+        'in a future release; use DecoLite::Model#load! instead!'
+      expect { subject }.to output(a_string_including(warning)).to_stdout
     end
   end
 
@@ -72,16 +115,16 @@ RSpec.describe DecoLite::Model, type: :model do
           @required_fields
         end
       end.new(hash: hash, options: options, required_fields: required_fields)
-        .load(hash: hash)
+        .load!(hash: hash)
     end
 
     before do
       subject.validate
     end
 
-    let(:required_fields) { [] }
-
     context 'when #required_fields is blank?' do
+      let(:required_fields) { [] }
+
       it_behaves_like 'there are no errors'
     end
 
@@ -125,6 +168,11 @@ RSpec.describe DecoLite::Model, type: :model do
     end
 
     context 'when there are fields' do
+      let!(:conflict) do
+        described_class.new(options: options)
+          .load!(hash: hash, options: load_options)
+      end
+
       it 'returns an array of field names' do
         expect(subject.field_names).to eq field_names
       end
@@ -151,6 +199,7 @@ RSpec.describe DecoLite::Model, type: :model do
           c1_e_f_g: :c1_e_f_g
         }
       end
+
       it 'returns an empty Hash' do
         expect(subject.to_h).to eq expected_hash
       end

--- a/spec/support/shared_examples/model_examples.rb
+++ b/spec/support/shared_examples/model_examples.rb
@@ -20,7 +20,9 @@ end
 
 RSpec.shared_examples 'an error is raised' do
   it 'raises an error' do
-    expect { subject }.to raise_error expected_error
+    expect do
+      subject.load(hash: hash, options: load_options)
+    end.to raise_error expected_error
   end
 end
 


### PR DESCRIPTION
- Change DecoLite::Model#load to #load! as it alters the object,
give deprecation warning when calling #load.
- FieldConflictable now expliticly prohibits loading fields that
conflict with attributes that are native to the receiver. In other
words, you cannot load fields with names like :to_s, :tap, :hash,
etc.
- FieldCreatable now creates attr_accessors on the instance using
(i.e. self.class.attr_accessor) (see bug fixes).
- bug fixes
-- Fix bug that used self.class.attr_accessor in
DecoLite::FieldCreatable to create attributes, which forced every
object of that class subsequently created have the accessors created
which caused field name conflicts across DecoLite::Model objects.