### PR TITLE
Changes and bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@
 /.vscode/
 *.code-workspace
 
-scratch.rb
+scratch*.rb
 readme.txt

--- a/.reek.yml
+++ b/.reek.yml
@@ -1,7 +1,7 @@
 exclude_paths:
   - vendor
   - spec
-  - scratch.rb
+  - scratch*.rb
 detectors:
   # TooManyInstanceVariables:
   #  exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
     - '*.gemspec'
     - 'spec/**/*'
     - 'vendor/**/*'
-    - 'scratch.rb'
+    - 'scratch*.rb'
 
 # Align the elements of a hash literal if they span more than one line.
 Layout/HashAlignment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.3.2
+* Changes
+  * Refactor FieldAssignable to remove call to FieldCreatable#create_field_accessor as this breaks single responsibility rule; which, in this case, makes sense to remove. FieldCreatable#create_field_accessor can be called wherever creation of a attr_accessor is needed.
+  * Refactor specs in keeping with above changes.
+  * README.md changes.
+* Bugs
+  * Fix bug where loading fields with the options: { fields: :strict } option raises an error for field that already exists.
+
 ### 0.3.1
 * Changes
   * Added `DecoLite::FieldRequireable::MISSING_REQUIRED_FIELD_ERROR_TYPE` for required field type errors.

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 
 ## Introduction
 
-DecoLite is in development. I wouldn't expect breaking changes before v1.0.0; however, I can't completely rule this out. Currently, DecoLite only supports Hashes whose keys are `Symbols`, contain no embedded spaces, and conform to Ruby `attr_accessor` naming conventions. However, I'll certainly work out a solution for all this in future releases.
+DecoLite is in development. I wouldn't expect breaking changes before v1.0.0; however, I can't completely rule this out. Currently, DecoLite only supports Hashes whose keys are `Symbols`, contain no embedded spaces, and conform to Ruby `attr_accessor` naming conventions. However, I might try work out a reasonable solution for all this in future releases if the need is there.
 
-TBD: Documentation regarding `DecoLite::Model` options, `DecoLite::Model#load!` options: how these work, and how they play together (in the meantime, see the specs).
+TBD: Documentation regarding `DecoLite::Model` options, `DecoLite::Model#load!` options: how these work, and how they play together (e.g. options `fields: :merge` and `fields: :strict` for example; in the meantime, see the specs).
 
 _Deco_ is a little gem that allows you to use the provided `DecoLite::Model` class (`include ActiveModel::Model`) to create Decorator classes which can be instantiated and used. Inherit from `DecoLite::Model` to create your own unique classes with custom functionality. A `DecoLite::Model` includes `ActiveModel::Model`, so validation can be applied using [ActiveModel validation helpers](https://api.rubyonrails.org/v6.1.3/classes/ActiveModel/Validations/HelperMethods.html) you are familiar with; or, you can roll your own - just like any other ActiveModel.
 
-A `DecoLite::Model` will allow you to consume a Ruby Hash that you supply via the `DecoLite::Model#load!` method. Your supplied Ruby Hashes are used to create `attr_accessor` attributes (_"fields"_) on the model. Each attribute created, is then assigned its value from the Hash loaded.
+A `DecoLite::Model` will allow you to consume a Ruby Hash that you supply via the initializer (`DecoLite::Model#new`) or via the `DecoLite::Model#load!` method. Your supplied Ruby Hashes are used to create `attr_accessor` attributes (_"fields"_) on the model. Each attribute created, is then assigned its value from the Hash loaded.
 
 `attr_accessor` names created are _mangled_ to include namespacing. This creates unique attribute names for nested Hashes that may include non-unique keys. For example:
 
@@ -34,10 +34,11 @@ family = {
   }
 }
 ```
-Given the above example, DecoLite will produce the following `attr_accessors` on the `DecoLite::Model` object when loaded (`DecoLite::Model#load!`), and assign the values:
+Given the above example, DecoLite will produce the following `attr_accessors` on the `DecoLite::Model` object when loaded, and assign the values:
 
 ```ruby
-model = DecoLite::Model.new.load!(hash: family)
+# Or DecoLite::Model.new.load!(hash: family)
+model = DecoLite::Model.new(hash: family)
 
 model.name #=> 'John Doe'
 model.respond_to? :name= #=> true
@@ -59,7 +60,7 @@ grandpa = {
   name: 'Henry Doe',
   age: 85,
 }
-# The :name and :age Hash keys above will produce :name/:name= and :age/:age= attr_accessors and clash because these were already added to the model when "John Doe" was loaded with the first call to DecoLite::Model#load!.
+# The :name and :age Hash keys above will produce :name/:name= and :age/:age= attr_accessors and clash because these were already added to the model when "John Doe" was loaded with the first call to DecoLite::Model.new(hash: family).
 ```
 
 However, passing a `namespace:` option (for example `namespace: :grandpa`) to the `DecoLite::Model#load!` method, would produce the following `attr_accessors`, ensuring their uniqueness:
@@ -108,9 +109,7 @@ class ViewModel < DecoLite::Model
   end
 end
 
-view_model = ViewModel.new
-
-view_model.load!(hash: { first: 'John', last: 'Doe' })
+view_model = ViewModel.new(hash: { first: 'John', last: 'Doe' })
 
 view_model.valid?
 #=> true

--- a/lib/deco_lite/field_assignable.rb
+++ b/lib/deco_lite/field_assignable.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require_relative 'field_creatable'
 require_relative 'field_retrievable'
 
 module DecoLite
   # Defines methods to assign model field values dynamically.
   module FieldAssignable
-    include FieldCreatable
     include FieldRetrievable
 
     def set_field_values(hash:, field_info:, options:)
@@ -16,10 +14,10 @@ module DecoLite
       end
     end
 
+    # rubocop:disable Lint/UnusedMethodArgument
     def set_field_value(field_name:, value:, options:)
-      # Create our fields before we send.
-      create_field_accessor field_name: field_name, options: options
       send("#{field_name}=", value)
     end
+    # rubocop:enable Lint/UnusedMethodArgument
   end
 end

--- a/lib/deco_lite/field_conflictable.rb
+++ b/lib/deco_lite/field_conflictable.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'field_name_namespaceable'
+require_relative 'field_requireable'
 require_relative 'fields_optionable'
 
 module DecoLite
@@ -9,6 +10,7 @@ module DecoLite
   module FieldConflictable
     include FieldNameNamespaceable
     include FieldsOptionable
+    include FieldRequireable
 
     def validate_field_conflicts!(field_name:, options:)
       return unless field_conflict?(field_name: field_name, options: options)

--- a/lib/deco_lite/hash_loadable.rb
+++ b/lib/deco_lite/hash_loadable.rb
@@ -2,11 +2,13 @@
 
 require 'mad_flatter'
 require_relative 'field_assignable'
+require_relative 'field_creatable'
 
 module DecoLite
   # Provides methods to load and return information about a given hash.
   module HashLoadable
     include FieldAssignable
+    include FieldCreatable
 
     private
 

--- a/lib/deco_lite/hashable.rb
+++ b/lib/deco_lite/hashable.rb
@@ -5,7 +5,11 @@ module DecoLite
   module Hashable
     def to_h
       field_names.each_with_object({}) do |field_name, hash|
-        hash[field_name] = public_send field_name
+        field_value = public_send(field_name)
+
+        field_name, field_value = yield [field_name, field_value] if block_given?
+
+        hash[field_name] = field_value
       end
     end
   end

--- a/lib/deco_lite/model.rb
+++ b/lib/deco_lite/model.rb
@@ -47,7 +47,6 @@ module DecoLite
       # options while loading, but also provide option customization
       # of options when needed.
       options = Options.with_defaults(options, defaults: self.options)
-
       load_hash(hash: hash, deco_lite_options: options)
 
       self

--- a/lib/deco_lite/version.rb
+++ b/lib/deco_lite/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the version of this gem.
 module DecoLite
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/spec/lib/deco_lite/field_creatable_spec.rb
+++ b/spec/lib/deco_lite/field_creatable_spec.rb
@@ -1,7 +1,9 @@
 RSpec.describe DecoLite::FieldCreatable, type: :module do
   subject(:klass) do
     class AwesomeKlass
+      include DecoLite::FieldAssignable
       include DecoLite::FieldCreatable
+      include DecoLite::FieldNamesPersistable
     end.new
   end
 

--- a/spec/lib/deco_lite/model_spec.rb
+++ b/spec/lib/deco_lite/model_spec.rb
@@ -23,17 +23,11 @@ end
 
 RSpec.shared_examples 'conflicting field names raise an error' do
   subject do
-    described_class.new(options: options)
-      .load!(hash: hash, options: fields_merge_options)
-  end
-
-  let(:model) do
-    described_class.new(options: options)
-      .load!(hash: hash, options: load_options)
+    described_class.new(hash: hash, options: options)
   end
 
   it 'raises an error due to conflicting field names' do
-    expect { model }.to raise_error /conflicts with existing method\(s\)/
+    expect { subject.load!(hash: hash, options: load_options) }.to raise_error /conflicts with existing method\(s\)/
   end
 
   it do


### PR DESCRIPTION
* Changes
  * Refactor FieldAssignable to remove call to
FieldCreatable#create_field_accessor as this breaks
single responsibility rule; which, in this case, makes
sense to remove. FieldCreatable#create_field_accessor
can be called wherever creation of a attr_accessor is needed.
  * Refactor specs in keeping with above changes.
  * README.md changes.
* Bugs
  * Fix bug where loading fields with the options: { fields: :strict }
option raises an error for field that already exists.